### PR TITLE
Updating for base internationalization check

### DIFF
--- a/Sources/LocalizationServices/Bundle/LocaleLocalizableStringsBundle.swift
+++ b/Sources/LocalizationServices/Bundle/LocaleLocalizableStringsBundle.swift
@@ -20,7 +20,7 @@ public class LocaleLocalizableStringsBundle: LocalizableStringsBundle {
         self.locale = Locale(identifier: localeIdentifier)
         self.localeIdentifier = localeIdentifier
                 
-        if let localeBundle = localeBundleLoader.bundleForResource(resourceName: localeIdentifier) {
+        if let localeBundle = localeBundleLoader.bundleForResource(bundleFilename: localeIdentifier) {
             super.init(bundle: localeBundle.bundle)
         }
         else {

--- a/Sources/LocalizationServices/BundleLoader/BaseInternationalization.swift
+++ b/Sources/LocalizationServices/BundleLoader/BaseInternationalization.swift
@@ -19,6 +19,6 @@ public struct BaseInternationalization {
     }
     
     var isEnglish: Bool {
-        return baseLanguage == "en"
+        return LocalizableStringsBundleLoader.possibleEnglishBundleFilenames.contains(baseLanguage)
     }
 }

--- a/Sources/LocalizationServices/BundleLoader/BaseInternationalization.swift
+++ b/Sources/LocalizationServices/BundleLoader/BaseInternationalization.swift
@@ -1,0 +1,24 @@
+//
+//  BaseInternationalization.swift
+//  LocalizationServices
+//
+//  Created by Levi Eggert on 7/23/25.
+//
+
+import Foundation
+
+public struct BaseInternationalization {
+    
+    public static let baseBundleFilename: String = "Base"
+    
+    public let baseLanguage: String
+    
+    public init(baseLanguage: String) {
+        
+        self.baseLanguage = baseLanguage
+    }
+    
+    var isEnglish: Bool {
+        return baseLanguage == "en"
+    }
+}

--- a/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
+++ b/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
@@ -10,13 +10,6 @@ import Foundation
 
 public class LocalizableStringsBundleLoader {
     
-    // NOTE: Will be Base if Use Base Internationalization is checked in Project > Info > Localizations Section.
-    //       English.lproj is deprecated for Localizable.strings. ~Levi
-    public static let englishLocalizableStringsFile: String = "Base"
-    
-    // NOTE: Stringsdict still uses deprecated English.lproj. ~Levi
-    public static let englishLocalizableStringsdictFile: String = "Base"
-    
     public let localizableStringsFilesBundle: Bundle
     
     public init(localizableStringsFilesBundle: Bundle?) {
@@ -40,7 +33,7 @@ public class LocalizableStringsBundleLoader {
         let bundle: Bundle?
         
         if isEnglishResource {
-            bundle = getBundle(bundleFilename: "Base") ?? getBundle(bundleFilename: "English")
+            bundle = getBundle(bundleFilename: "Base") ?? getBundle(bundleFilename: "en") ?? getBundle(bundleFilename: "English")
         }
         else {
             bundle = getBundle(bundleFilename: resourceName)

--- a/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
+++ b/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
@@ -33,7 +33,19 @@ public class LocalizableStringsBundleLoader {
         let bundle: Bundle?
         
         if isEnglishResource {
-            bundle = getBundle(bundleFilename: "Base") ?? getBundle(bundleFilename: "en") ?? getBundle(bundleFilename: "English")
+            
+            if let baseBundle = getBundle(bundleFilename: "Base") {
+                bundle = baseBundle
+            }
+            else if let enBundle = getBundle(bundleFilename: "en") {
+                bundle = enBundle
+            }
+            else if let englishBundle = getBundle(bundleFilename: "English") {
+                bundle = englishBundle
+            }
+            else {
+                bundle = nil
+            }
         }
         else {
             bundle = getBundle(bundleFilename: resourceName)

--- a/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
+++ b/Sources/LocalizationServices/BundleLoader/LocalizableStringsBundleLoader.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class LocalizableStringsBundleLoader {
     
-    private static let possibleEnglishBundleFilenames: [String] = [
+    public static let possibleEnglishBundleFilenames: [String] = [
         LocalizableStringsBundleLoader.enBundleFilename,
         LocalizableStringsBundleLoader.englishBundleFilename
     ]
@@ -21,12 +21,14 @@ public class LocalizableStringsBundleLoader {
     public let localizableStringsFilesBundle: Bundle
     public let baseInternationalization: BaseInternationalization?
     
-    public init(localizableStringsFilesBundle: Bundle?, isUsingBaseInternationalization: Bool, baseInternationalizationBaseLanguage: String = "en") {
+    public init(localizableStringsFilesBundle: Bundle?, isUsingBaseInternationalization: Bool, baseInternationalizationBaseLanguage: String? = nil) {
         
         self.localizableStringsFilesBundle = localizableStringsFilesBundle ?? Bundle.main
         
         if isUsingBaseInternationalization {
-            baseInternationalization = BaseInternationalization(baseLanguage: baseInternationalizationBaseLanguage)
+            baseInternationalization = BaseInternationalization(
+                baseLanguage: baseInternationalizationBaseLanguage ?? Self.enBundleFilename
+            )
         }
         else {
             baseInternationalization = nil

--- a/Sources/LocalizationServices/LocalizationServices.swift
+++ b/Sources/LocalizationServices/LocalizationServices.swift
@@ -13,9 +13,12 @@ public class LocalizationServices: LocalizationServicesInterface {
     public let stringsRepository: LocalizableStringsRepository
     public let bundleLoader: LocalizableStringsBundleLoader
     
-    public init(localizableStringsFilesBundle: Bundle?) {
+    public init(localizableStringsFilesBundle: Bundle?, isUsingBaseInternationalization: Bool) {
         
-        let bundleLoader = LocalizableStringsBundleLoader(localizableStringsFilesBundle: localizableStringsFilesBundle)
+        let bundleLoader = LocalizableStringsBundleLoader(
+            localizableStringsFilesBundle: localizableStringsFilesBundle,
+            isUsingBaseInternationalization: isUsingBaseInternationalization
+        )
         
         self.stringsRepository = LocalizableStringsRepository(localizableStringsBundleLoader: bundleLoader)
         self.bundleLoader = bundleLoader

--- a/Tests/LocalizationServicesTests/LocalizationServices/BundleLoader/LocalizableStringsBundleLoaderTests.swift
+++ b/Tests/LocalizationServicesTests/LocalizationServices/BundleLoader/LocalizableStringsBundleLoaderTests.swift
@@ -13,7 +13,15 @@ class LocalizableStringsBundleLoaderTests: XCTestCase {
     
     static let missingLocalizableStringsResource: String = "ru"
     
-    private let bundleLoader: LocalizableStringsBundleLoader = LocalizableStringsBundleLoader(localizableStringsFilesBundle: Bundle.getTestBundle())
+    private let bundleLoaderUsingBaseInternationalization: LocalizableStringsBundleLoader = LocalizableStringsBundleLoader(
+        localizableStringsFilesBundle: Bundle.getTestBundle(),
+        isUsingBaseInternationalization: true
+    )
+    
+    private let bundleLoaderNotUsingBaseInternationalization: LocalizableStringsBundleLoader = LocalizableStringsBundleLoader(
+        localizableStringsFilesBundle: Bundle.getTestBundle(),
+        isUsingBaseInternationalization: false
+    )
     
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -23,42 +31,90 @@ class LocalizableStringsBundleLoaderTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
-    func testLoadingEnglishLocalizableStringsExists() {
-                                    
-        XCTAssertNotNil(bundleLoader.getEnglishBundle(), "Failed to load English localizable strings.")
+    func testLoadingBaseLocalizableStringsExists() {
         
-        XCTAssertNotNil(bundleLoader.bundleForResource(resourceName: LocaleId.english.id), "Failed to load English localizable strings.")
     }
     
-    func testLoadingEnglishLocalizableStringsDictExists() {
-                           
-        XCTAssertNotNil(bundleLoader.getEnglishBundle(), "Failed to load English localizable stringsdict.")
+    func testLoadingBaseLocalizableStringsExistsWhenUsingBaseInternationalization() {
+                                            
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: BaseInternationalization.baseBundleFilename), "Failed to load Base localizable strings.")
+    }
+    
+    func testLoadingBaseLocalizableStringsDictExistsWhenUsingBaseInternationalization() {
+                                   
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: BaseInternationalization.baseBundleFilename), "Failed to load Base localizable stringsdict.")
+    }
+    
+    func testLoadingBaseLocalizableStringsDoesNotExistWhenNotUsingBaseInternationalization() {
+                                            
+        XCTAssertNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: BaseInternationalization.baseBundleFilename), "Should not load Base localizable strings.")
+    }
+    
+    func testLoadingBaseLocalizableStringsDictDoesNotExistWhenNotUsingBaseInternationalization() {
+                                   
+        XCTAssertNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: BaseInternationalization.baseBundleFilename), "Should not load Base localizable stringsdict.")
+    }
+    
+    func testLoadingEnglishLocalizableStringsExistsWhenUsingBaseInternationalization() {
+                                    
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.getEnglishBundle(), "Failed to load English localizable strings.")
         
-        XCTAssertNotNil(bundleLoader.bundleForResource(resourceName: LocaleId.english.id), "Failed to load English localizable stringsdict.")
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.english.id), "Failed to load English localizable strings.")
+    }
+    
+    func testLoadingEnglishLocalizableStringsDictExistsWhenUsingBaseInternationalization() {
+                           
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.getEnglishBundle(), "Failed to load English localizable stringsdict.")
+        
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.english.id), "Failed to load English localizable stringsdict.")
+    }
+    
+    func testLoadingEnglishLocalizableStringsExistsWhenNotUsingBaseInternationalization() {
+                                    
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.getEnglishBundle(), "Failed to load English localizable strings.")
+        
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.english.id), "Failed to load English localizable strings.")
+    }
+    
+    func testLoadingEnglishLocalizableStringsDictExistsWhenNotUsingBaseInternationalization() {
+                           
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.getEnglishBundle(), "Failed to load English localizable stringsdict.")
+        
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.english.id), "Failed to load English localizable stringsdict.")
     }
     
     func testLoadingSpanishLocalizableStringsExists() {
                                             
-        XCTAssertNotNil(bundleLoader.bundleForResource(resourceName: LocaleId.spanish.id), "Failed to load Spanish localizable strings.")
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.spanish.id), "Failed to load Spanish localizable strings.")
+        
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.spanish.id), "Failed to load Spanish localizable strings.")
     }
     
     func testLoadingSpanishLocalizableStringsDictExists() {
                                    
-        XCTAssertNotNil(bundleLoader.bundleForResource(resourceName: LocaleId.spanish.id), "Failed to load Spanish localizable stringsdict.")
+        XCTAssertNotNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.spanish.id), "Failed to load Spanish localizable stringsdict.")
+        
+        XCTAssertNotNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocaleId.spanish.id), "Failed to load Spanish localizable stringsdict.")
     }
     
     func testLoadingLocalizableStringsBundleDoesNotExist() {
                 
-        XCTAssertNil(bundleLoader.bundleForResource(resourceName: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
+        XCTAssertNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
+        
+        XCTAssertNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
     }
     
     func testLoadingLocalizableStringsdictBundleDoesNotExist() {
         
-        XCTAssertNil(bundleLoader.bundleForResource(resourceName: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
+        XCTAssertNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
+        
+        XCTAssertNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: LocalizableStringsBundleLoaderTests.missingLocalizableStringsResource))
     }
     
-    func testEmptyResourceNameShouldReturnNil() {
+    func testEmptyBundleFilenameShouldReturnNil() {
         
-        XCTAssertNil(bundleLoader.bundleForResource(resourceName: ""))
+        XCTAssertNil(bundleLoaderUsingBaseInternationalization.bundleForResource(bundleFilename: ""))
+        
+        XCTAssertNil(bundleLoaderNotUsingBaseInternationalization.bundleForResource(bundleFilename: ""))
     }
 }

--- a/Tests/LocalizationServicesTests/LocalizationServices/LocalizationServicesTests.swift
+++ b/Tests/LocalizationServicesTests/LocalizationServices/LocalizationServicesTests.swift
@@ -11,7 +11,10 @@ import XCTest
 
 class LocalizationServicesTests: XCTestCase {
  
-    private let localizationServices: LocalizationServices = LocalizationServices(localizableStringsFilesBundle: Bundle.getTestBundle())
+    private let localizationServices: LocalizationServices = LocalizationServices(
+        localizableStringsFilesBundle: Bundle.getTestBundle(),
+        isUsingBaseInternationalization: true
+    )
     
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/Tests/LocalizationServicesTests/LocalizationServices/Repository/LocalizableStringsRepositoryTests.swift
+++ b/Tests/LocalizationServicesTests/LocalizationServices/Repository/LocalizableStringsRepositoryTests.swift
@@ -12,7 +12,10 @@ import XCTest
 class LocalizableStringsRepositoryTests: XCTestCase {
  
     private let stringsRepository: LocalizableStringsRepository = LocalizableStringsRepository(
-        localizableStringsBundleLoader: LocalizableStringsBundleLoader(localizableStringsFilesBundle: Bundle.getTestBundle())
+        localizableStringsBundleLoader: LocalizableStringsBundleLoader(
+            localizableStringsFilesBundle: Bundle.getTestBundle(),
+            isUsingBaseInternationalization: true
+        )
     )
     
     override func setUp() {


### PR DESCRIPTION
LocalizationServices now handles whether base internationalization is checked or not in Xcode.  If checked, Base.lproj resource is expected.  If unchecked, en.lproj is expected.